### PR TITLE
nameservice: bump version to 0.4

### DIFF
--- a/lib/nameservice/Makefile
+++ b/lib/nameservice/Makefile
@@ -43,7 +43,7 @@
 
 OLSRD_PLUGIN =	true
 PLUGIN_NAME =	olsrd_nameservice
-PLUGIN_VER =	0.3
+PLUGIN_VER =	0.4
 
 TOPDIR = ../..
 include $(TOPDIR)/Makefile.inc


### PR DESCRIPTION
for the new parameter "filewrite-interval" we should bump the version, so init-scripts can give correct parameters.
Automatic generate config-files (like in OpenWrt from UCI-settings) have no knowledge if this parameter can be added to configfile when there is all the same version.

Signed-off-by: Sven Roederer <freifunk@it-solutions.geroedel.de>